### PR TITLE
ORC-FORMAT-6: Add `CompressionKind.BROTLI`

### DIFF
--- a/src/main/proto/orc/proto/orc_proto.proto
+++ b/src/main/proto/orc/proto/orc_proto.proto
@@ -387,6 +387,7 @@ enum CompressionKind {
   LZO = 3;
   LZ4 = 4;
   ZSTD = 5;
+  BROTLI = 6;
 }
 
 // Serialized length must be less that 255 bytes


### PR DESCRIPTION
### What changes were proposed in this pull request?

This closes #6 by adding `CompressionKind.BROTLI` as a new compression type.

### Why are the changes needed?

To support ORC-1463 at Apache ORC Format 1.0.0.

### How was this patch tested?

Pass the CIs.