### PR TITLE
ORC-FORMAT-8: Add `maven-enforcer-plugin` to enforce Java and Maven versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,39 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.4.0</version>
+                <dependencies>
+                <dependency>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>extra-enforcer-rules</artifactId>
+                    <version>1.7.0</version>
+                </dependency>
+                </dependencies>
+                <executions>
+                <execution>
+                    <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${maven.version}</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${java.version}</version>
+                                </requireJavaVersion>
+                                <enforceBytecodeVersion>
+                                    <maxJdkVersion>${java.version}</maxJdkVersion>
+                                </enforceBytecodeVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
             </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This closes #8 .

### Why are the changes needed?

To be compatible with Apache ORC 2.0.0, we need to enforce Java and Maven versions.

### How was this patch tested?

Pass the CIs.