### PR TITLE
ORC-FORMAT-10: Updated Maven version to 3.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-        <maven.version>3.9.4</maven.version>
+        <maven.version>3.9.6</maven.version>
         <protoc.version>3.17.3</protoc.version>
         <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
     </properties>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This closes #10.

The PR aims at upgrading Maven version to 3.9.6

### Why are the changes needed?
The details are captured as part of PR https://github.com/apache/orc/pull/1687


### How was this patch tested?
Local build to be successful and CI passes
