### PR TITLE
ORC-FORMAT-23: Setting version to 1.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </parent>
     <groupId>org.apache.orc</groupId>
     <artifactId>orc-format</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Apache ORC Format</name>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set versions to 1.1.0-SNAPSHOT.

### Why are the changes needed?

To prepare Apache ORC 1.1.0 release.

### How was this patch tested?

Manual review.

Closes #23