### PR TITLE
Upgrade protoc and protobuf version to 3.25.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
         <maven.version>3.9.6</maven.version>
-        <protoc.version>3.17.3</protoc.version>
+        <protoc.version>3.25.8</protoc.version>
         <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
     </properties>
 
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.25.5</version>
+            <version>3.25.8</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?
Using ORC 2.1.3, `protobuf.GeneratedMessage` will output some warning information.

https://github.com/apache/orc/pull/2305


### How was this patch tested?
local test

After regenerating orc-format, no warning.